### PR TITLE
docs(designs): fix broken links

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -1,9 +1,7 @@
 # Design Description
 
-Refer [design description](./MPW_Design_Description.md), which consists of a
-description of the Efabless MPW shuttle design list currently in
-the CI. This [list](./MPW_Design_Description.md) have MPW shuttle
-based designs details with following order:
+This file consists of the Efabless shuttle digital design list currently
+in the CI. The designs in this list have the following structure:
 
 -   `CI Design Name`
     -   `Project Name:`


### PR DESCRIPTION
While deleting `designs/MPW_Design_Description.md` and copying the content to `designs/README.md` in 6e562657e58ca9e4a23e164da74a00addb85ecaf, several links broke. As the content is now in the same file I deleted the links and rewritten the description.