### PR TITLE
fix fossiAES linter error

### DIFF
--- a/scripts/fossiAES/config.tcl
+++ b/scripts/fossiAES/config.tcl
@@ -2,6 +2,5 @@ cd [file dirname [file normalize [info script]]]
 set ::env(CARAVEL_ROOT) "$::env(DESIGN_DIR)/caravel"
 set ::env(DESIGN_IS_CORE) 1
 set ::env(FP_IO_UNMATCHED_ERROR) 0
-set ::env(QUIT_ON_LINTER_ERRORS) 0
-set ::env(QUIT_ON_SYNTH_CHECKS) 0
+set ::env(VERILOG_FILES) [glob $::env(DESIGN_DIR)/verilog/rtl/aes/generated/*.v]
 source $::env(DESIGN_DIR)/openlane/aes/config.tcl

--- a/scripts/fossiAES/setup-flow.sh
+++ b/scripts/fossiAES/setup-flow.sh
@@ -4,3 +4,4 @@ sed -i '/::env(GLB_RT_MAXLAYER)/d' ${design_dir}/openlane/aes/config.tcl
 sed -i '/::env(RT_MAX_LAYER)/d' ${design_dir}/openlane/aes/config.tcl
 sed -i '/::env(DIODE_INSERTION_STRATEGY)/d' ${design_dir}/openlane/aes/config.tcl
 sed -i 's/GLB_RT/GRT/g' ${design_dir}/openlane/aes/config.tcl
+sed -i '24,25d' ${design_dir}/openlane/aes/config.tcl


### PR DESCRIPTION
As per discussion https://github.com/The-OpenROAD-Project/OpenLane/discussions/1965 to resolve following linter error only 
```
%Error: Cannot find file containing module: /openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v
%Error: This may be because there's no search path specified with -I<dir>.
        ... Looked in:
             /openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v
             /openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v.v
             /openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v.sv
             obj_dir//openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v
             obj_dir//openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v.v
             obj_dir//openlane/designs/fossiAES/openlane/aes/../../verilog/rtl/aes/generated/*.v.sv
%Error: Exiting due to 2 error(s)
```
Append `glob` with verilog file list. Same thing updated for PR #185.